### PR TITLE
Onboard SD menu changes

### DIFF
--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -179,15 +179,20 @@ void menu_main() {
         if (!card_open) {
           MENU_ITEM(submenu, MSG_CARD_MENU, menu_sdcard);
           #if !PIN_EXISTS(SD_DETECT)
-            MENU_ITEM(gcode, MSG_CHANGE_SDCARD, PSTR("M21"));  // SD-card changed by user
+            #if ENABLED(USB_SD_ONBOARD)
+              MENU_ITEM(gcode, MSG_RELEASE_SDCARD, PSTR("M22"));  // Release onboard SD card for USB access
+            #else
+              MENU_ITEM(gcode, MSG_CHANGE_SDCARD, PSTR("M21"));  // SD-card changed by user
+            #endif
           #endif
         }
       }
       else {
         #if !PIN_EXISTS(SD_DETECT)
           MENU_ITEM(gcode, MSG_INIT_SDCARD, PSTR("M21")); // Manually init SD-card
+        #elif !ENABLED(USB_SD_ONBOARD)  // Prevent 'No SD card' message with onboard SD
+          MENU_ITEM(function, MSG_NO_CARD, NULL);
         #endif
-        MENU_ITEM(function, MSG_NO_CARD, NULL);
       }
     #endif // !HAS_ENCODER_WHEEL && SDSUPPORT
 
@@ -260,15 +265,20 @@ void menu_main() {
       if (!card_open) {
         MENU_ITEM(submenu, MSG_CARD_MENU, menu_sdcard);
         #if !PIN_EXISTS(SD_DETECT)
-          MENU_ITEM(gcode, MSG_CHANGE_SDCARD, PSTR("M21"));  // SD-card changed by user
+          #if ENABLED(USB_SD_ONBOARD)
+            MENU_ITEM(gcode, MSG_RELEASE_SDCARD, PSTR("M22"));  // Release onboard SD card for USB access
+          #else
+            MENU_ITEM(gcode, MSG_CHANGE_SDCARD, PSTR("M21"));  // SD-card changed by user
+          #endif
         #endif
       }
     }
     else {
       #if !PIN_EXISTS(SD_DETECT)
         MENU_ITEM(gcode, MSG_INIT_SDCARD, PSTR("M21")); // Manually init SD-card
+      #elif !ENABLED(USB_SD_ONBOARD)  // Prevent 'No SD card' message with onboard SD
+        MENU_ITEM(function, MSG_NO_CARD, NULL);
       #endif
-      MENU_ITEM(function, MSG_NO_CARD, NULL);
     }
   #endif // HAS_ENCODER_WHEEL && SDSUPPORT
 


### PR DESCRIPTION
Added "Release SD card' menu item for onboard SD cards, makes it easier to mount onboard SD through USB.

Removed unnecessary 'No SD card' message when using onboard SD.

Also adding MSG_RELEASE_SDCARD to language_en.h

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
